### PR TITLE
Run plugin in non-VRChat platforms

### DIFF
--- a/Packages/net.nekobako.blend-shape-modifier/Editor/BlendShapeModifierPlugin.cs
+++ b/Packages/net.nekobako.blend-shape-modifier/Editor/BlendShapeModifierPlugin.cs
@@ -6,6 +6,7 @@ using net.nekobako.BlendShapeModifier.Editor;
 
 namespace net.nekobako.BlendShapeModifier.Editor
 {
+    [RunsOnAllPlatforms]
     internal class BlendShapeModifierPlugin : Plugin<BlendShapeModifierPlugin>
     {
         public override string QualifiedName => "net.nekobako.blend-shape-modifier";

--- a/Packages/net.nekobako.blend-shape-modifier/package.json
+++ b/Packages/net.nekobako.blend-shape-modifier/package.json
@@ -11,7 +11,6 @@
   "license": "MIT",
   "url": "https://github.com/nekobako/BlendShapeModifier/releases/download/0.0.1/net.nekobako.blend-shape-modifier-0.0.1.zip",
   "vpmDependencies": {
-    "com.vrchat.avatars": ">=3.8.2",
     "nadena.dev.ndmf": ">=1.8.2"
   }
 }


### PR DESCRIPTION
Currently, when BlendShapeModifier is installed in a non-VRChat project (such as a project that is using the Basis framework), attempting to build an avatar using NDMF will skip the BlendShapeModifierPlugin, resulting in no effect on the final blendshapes. This is because by default, a NDMF plugin that is tagged by neither RunsOnAllPlatforms nor RunsOnPlatforms will only be allowed to run if the avatar is being built for the VRChat platform.

This is despite BlendShapeModifier having no actual code dependency on the VRChat SDK.

This pull request modifies BlendShapeModifier so that it may be installed using ALCOM and benefit from use in avatar projects other than VRChat.

- Add NDMF *[RunsOnAllPlatforms](https://ndmf.nadena.dev/api/nadena.dev.ndmf.RunsOnAllPlatforms.html)*, because this plugin does not rely on platform-specific APIs.
  - That said, GLB/GLTF is unlikely to support multi-frame blendshapes, so this plugin might not produce an usable output in formats such as VRM. Also, Modular Avatar for Resonite seems to serialize all blendshape frames, but I have not verified whether or not Resonite actually supports it.
- I have confirmed this plugin is working on a Basis Framework avatar project in Unity 6.
- If installed through ALCOM, it should no longer prompt installation of the VRChat SDK in non-VRChat projects.